### PR TITLE
Prevent Unrelated Error Upon Invalid Formula

### DIFF
--- a/R/ChemicalCuration.R
+++ b/R/ChemicalCuration.R
@@ -178,6 +178,7 @@ getAdductMassesFromFormula <- function(MolForm) {
     MpNH4_mass <- ""
     MpNa_mass <- ""
     MmHm_mass <- ""
+    MpFAm_mass <- ""
     print(paste0("Invalid formula: ", MolForm))
   } else {
     # calculate masses


### PR DESCRIPTION
Currently, when calling `getAdductMassesFromFormula` with an invalid formula, an error of type `Undefined object MpFAm_mass` is thrown. This change should prevent that.